### PR TITLE
Fix product not found causing index out of bounds crash

### DIFF
--- a/Sources/bevy_ios_iap/BevyIosIAP.swift
+++ b/Sources/bevy_ios_iap/BevyIosIAP.swift
@@ -46,6 +46,12 @@ public func ios_iap_purchase(id: RustString)
         do {
             let productIds = [id.toString()]
             let products = try await Product.products(for: productIds)
+            
+            if products.count < 1 {
+                purchase_processed(IosIapPurchaseResult.error("Could not find product: {}" + id.toString()))
+                return;
+            }
+            
             let purchase  = try await products[0].purchase()
             
             let result = switch purchase {


### PR DESCRIPTION
Does a length check on the products array before attempting to access. If no products are found it returns a transaction error

fixes #3 